### PR TITLE
Remove MSR Crypto package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   "dependencies": {
     "@privacyresearch/curve25519-typescript": "^0.0.9",
     "@privacyresearch/libsignal-protocol-protobuf-ts": "^0.0.7",
-    "base64-js": "^1.3.1",
-    "msrcrypto": "^1.5.8"
+    "base64-js": "^1.3.1"
   },
   "files": [
     "lib/*.js",

--- a/src/fingerprint-generator.ts
+++ b/src/fingerprint-generator.ts
@@ -1,8 +1,7 @@
 import { FingerprintGeneratorType } from './'
 import * as utils from './helpers'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-// const msrcrypto = require('../lib/msrcrypto')
-import msrcrypto from 'msrcrypto'
+const msrcrypto = require('../lib/msrcrypto')
 
 export class FingerprintGenerator implements FingerprintGeneratorType {
     static VERSION = 0

--- a/src/internal/crypto.ts
+++ b/src/internal/crypto.ts
@@ -1,10 +1,9 @@
 import * as Internal from '.'
 import * as util from '../helpers'
 import { KeyPairType } from '../types'
-import msrcrypto from 'msrcrypto'
 import { AsyncCurve as AsyncCurveType } from '@privacyresearch/curve25519-typescript'
 
-const webcrypto = window?.crypto || msrcrypto
+const webcrypto = globalThis?.crypto || window?.crypto || require('../../lib/msrcrypto')
 
 export class Crypto {
     private _curve: Internal.AsyncCurve

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,11 +2893,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-msrcrypto@^1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/msrcrypto/-/msrcrypto-1.5.8.tgz#be419be4945bf134d8af52e9d43be7fa261f4a1c"
-  integrity sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
The MSR Crypto npm package was causing failures in node environments. Removing it and relying on a fallback javascript file for clients that cannot inject their own.