### PR TITLE
Force msrCrypto.scriptURL to return null

### DIFF
--- a/lib/msrcrypto.js
+++ b/lib/msrcrypto.js
@@ -56,19 +56,6 @@ var msrCryptoVersion = '1.6.1'
     }
 
     var scriptUrl = (function () {
-      if (typeof document !== 'undefined') {
-        try {
-          throw new Error()
-        } catch (e) {
-          if (e.stack) {
-            var match = /\w+:\/\/(.+?\/)*.+\.js/.exec(e.stack)
-            return match && match.length > 0 ? match[0] : null
-          }
-        }
-      } else if (typeof self !== 'undefined') {
-        return self.location.href
-      }
-
       return null
     })()
 


### PR DESCRIPTION
Call to scriptURL causes crashes in react native