### PR TITLE
Update session-builder.ts

### DIFF
--- a/src/session-builder.ts
+++ b/src/session-builder.ts
@@ -55,7 +55,7 @@ export class SessionBuilder {
         const address = this.remoteAddress.toString()
         const serialized = await this.storage.loadSession(address)
         let record: SessionRecord
-        if (serialized !== undefined) {
+        if (serialized !== undefined && serialized != null) {
             record = SessionRecord.deserialize(serialized)
         } else {
             record = new SessionRecord()


### PR DESCRIPTION
fix
`
create_session error SignalProtocolAddress { _name: 'xxx', _deviceId: 1 } TypeError: Cannot read properties of null (reading 'version')
    at Function.deserialize (/root/xxx/node_modules/@privacyresearch/libsignal-protocol-typescript/lib/session-record.js:56:18)
    at SessionBuilder.<anonymous> (/root/xxx/node_modules/@privacyresearch/libsignal-protocol-typescript/lib/session-builder.js:64:57)
    at Generator.next (<anonymous>)
    at fulfilled (/root/xxx/node_modules/@privacyresearch/libsignal-protocol-typescript/lib/session-builder.js:24:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
`
