### PR TITLE
Fixed `EncryptionResultMessageType` flip

### DIFF
--- a/src/session-types.ts
+++ b/src/session-types.ts
@@ -53,8 +53,8 @@ export interface PendingPreKey<T> {
 }
 
 export enum EncryptionResultMessageType {
-    PreKeyWhisperMessage = 1,
-    WhisperMessage = 3,
+    WhisperMessage = 1,
+    PreKeyWhisperMessage = 3,
 }
 
 export interface EncryptionResult {


### PR DESCRIPTION
References issue https://github.com/privacyresearchgroup/libsignal-protocol-typescript/issues/81 
 
Incorrect type found here:
https://github.com/privacyresearchgroup/libsignal-protocol-typescript/blob/a4dd273e060c4131e1a7385adf92f367392ffaf5/src/session-types.ts#L55-L58

Actual usage:
https://github.com/privacyresearchgroup/libsignal-protocol-typescript/blob/a4dd273e060c4131e1a7385adf92f367392ffaf5/README.md?plain=1#L235-L247

Doesn't seem to be used anywhere else in the repo other than the type def for `EncryptionResult` (which also isn't used), but it's useful to have access to as a user of this library.